### PR TITLE
Security hardening: fix debug logging, postMessage origin, and weak KDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gooti
 
-## Nostr Identity Manager & Signer for Firefox
+## Nostr Identity Manager & Signer for Firefox (now with added security!)
 
 Gooti is a browser extension for managing multiple [Nostr](https://github.com/nostr-protocol/nostr) identities and for signing events on web apps without having to give them your keys.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ async window.nostr.nip44.decrypt(pubkey, ciphertext): string
 To build and run the Firefox extension from this code:
 
 ```
-git clone https://github.com/sam-hayes-org/gooti-extension
+git clone https://github.com/geeknik/gooti
 cd gooti-extension
 npm ci
 npm run build:firefox

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gooti
 
-## Nostr Identity Manager & Signer
+## Nostr Identity Manager & Signer for Firefox
 
 Gooti is a browser extension for managing multiple [Nostr](https://github.com/nostr-protocol/nostr) identities and for signing events on web apps without having to give them your keys.
 
@@ -20,30 +20,6 @@ async window.nostr.nip04.decrypt(pubkey, ciphertext): string
 async window.nostr.nip44.encrypt(pubkey, plaintext): string
 async window.nostr.nip44.decrypt(pubkey, ciphertext): string
 ```
-
-The repository is configured as monorepo to hold the extensions for Chrome and Firefox. 
-
-[Get the Firefox extension here!](https://addons.mozilla.org/en-US/firefox/addon/gooti/)
-
-[Get the Chrome extension here!](https://chromewebstore.google.com/detail/gooti/cpcnmacmpalecmijkbcajanpdlcgjpgj)
-
-## Develop Chrome Extension
-
-To build and run the Chrome extension from this code:
-
-```
-git clone https://github.com/sam-hayes-org/gooti-extension
-cd gooti-extension
-npm ci
-npm run build:chrome
-```
-
-then
-
-1. within Chrome go to `chrome://extensions`
-2. ensure "developer mode" is enabled on the top right
-3. click on "Load unpackaged"
-4. select the `dist/chrome` folder
 
 ## Develop Firefox Extension
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ then
 1. within Firefox go to `about://debugging`
 2. click "This Firefox" on the left
 3. click on "Load Temporary Add-on..."
-4. select the `dist/firefox` folder
+4. open `dist/firefox` and select the `manifest.json` file
 
 ---
 

--- a/projects/chrome/src/app/components/vault-import/vault-import.component.ts
+++ b/projects/chrome/src/app/components/vault-import/vault-import.component.ts
@@ -55,7 +55,7 @@ export class VaultImportComponent extends NavComponent implements OnInit {
   async #loadData() {
     this.snapshots = (
       this.#storage.getGootiMetaHandler().gootiMetaData?.vaultSnapshots ?? []
-    ).sortBy((x) => x.fileName, 'desc');
+    ).sortBy((x: GootiMetaData_VaultSnapshot) => x.fileName, 'desc');
 
     const syncFlow =
       this.#storage.getGootiMetaHandler().gootiMetaData?.syncFlow;

--- a/projects/chrome/src/background-common.ts
+++ b/projects/chrome/src/background-common.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   BackgroundCommon,
+  AutoLockConfig,
   BrowserSessionData,
   BrowserSyncData,
   BrowserSyncFlow,
@@ -126,11 +127,8 @@ export class ChromeBackgroundCommon extends BackgroundCommon {
         lastFocused.width !== undefined &&
         lastFocused.height !== undefined
       ) {
-        // Position window in the center of the lastFocused window
         top = Math.round(lastFocused.top + (lastFocused.height - height) / 2);
         left = Math.round(lastFocused.left + (lastFocused.width - width) / 2);
-      } else {
-        console.error('Last focused window properties are undefined.');
       }
     } catch (error) {
       console.error('Error getting window position:', error);
@@ -140,5 +138,20 @@ export class ChromeBackgroundCommon extends BackgroundCommon {
       top,
       left,
     };
+  }
+
+  async clearSessionData(): Promise<void> {
+    await chrome.storage.session.clear();
+  }
+
+  protected async getAutoLockConfigFromStorage(): Promise<AutoLockConfig | null> {
+    const result = await chrome.storage.local.get(this.AUTO_LOCK_CONFIG_KEY);
+    return result[this.AUTO_LOCK_CONFIG_KEY] ?? null;
+  }
+
+  protected async saveAutoLockConfigToStorage(
+    config: AutoLockConfig,
+  ): Promise<void> {
+    await chrome.storage.local.set({ [this.AUTO_LOCK_CONFIG_KEY]: config });
   }
 }

--- a/projects/chrome/src/background-common.ts
+++ b/projects/chrome/src/background-common.ts
@@ -84,7 +84,6 @@ export class ChromeBackgroundCommon extends BackgroundCommon {
       kind,
     };
 
-    // Store session data
     await chrome.storage.session.set({
       permissions: [...browserSessionData.permissions, permission.id],
     });
@@ -92,11 +91,13 @@ export class ChromeBackgroundCommon extends BackgroundCommon {
       [`permission_${permission.id}`]: permission,
     });
 
-    // Encrypt permission to store in sync storage (depending on sync flow).
+    const kdfParams = this.getKdfParams(browserSyncData);
     const encryptedPermission = await this.encryptPermission(
       permission,
       browserSessionData.iv,
       browserSessionData.vaultPassword as string,
+      kdfParams.salt,
+      kdfParams.iterations,
     );
 
     await this.savePermissionsToBrowserSyncStorage(

--- a/projects/chrome/src/background.ts
+++ b/projects/chrome/src/background.ts
@@ -2,4 +2,4 @@ import { initializeBackground } from '@common';
 import { ChromeBackgroundCommon } from './background-common';
 
 const backgroundCommon = new ChromeBackgroundCommon();
-initializeBackground(backgroundCommon);
+void initializeBackground(backgroundCommon);

--- a/projects/chrome/src/gooti-extension.ts
+++ b/projects/chrome/src/gooti-extension.ts
@@ -29,14 +29,12 @@ class Messenger {
           method,
           params,
         },
-        '*'
+        window.location.origin,
       );
     });
   }
 
   #handleCallResponse(message: MessageEvent) {
-    // We also will receive our own messages, that we sent.
-    // We have to ignore them (they will not have a response field).
     if (
       !message.data ||
       message.data.response === null ||
@@ -61,82 +59,50 @@ const nostr = {
   messenger: new Messenger(),
 
   async getPublicKey(): Promise<string> {
-    debug('getPublicKey received');
-    const pubkey = await this.messenger.request('getPublicKey', {});
-    debug(`getPublicKey response:`);
-    debug(pubkey);
-    return pubkey;
+    return await this.messenger.request('getPublicKey', {});
   },
 
   async signEvent(event: EventTemplate): Promise<Event> {
-    debug('signEvent received');
-    const signedEvent = await this.messenger.request('signEvent', event);
-    debug('signEvent response:');
-    debug(signedEvent);
-    return signedEvent;
+    return await this.messenger.request('signEvent', event);
   },
 
   async getRelays(): Promise<Relays> {
-    debug('getRelays received');
-    const relays = (await this.messenger.request('getRelays', {})) as Relays;
-    debug('getRelays response:');
-    debug(relays);
-    return relays;
+    return (await this.messenger.request('getRelays', {})) as Relays;
   },
 
   nip04: {
     that: this,
 
     async encrypt(peerPubkey: string, plaintext: string): Promise<string> {
-      debug('nip04.encrypt received');
-      const ciphertext = (await nostr.messenger.request('nip04.encrypt', {
+      return (await nostr.messenger.request('nip04.encrypt', {
         peerPubkey,
         plaintext,
       })) as string;
-      debug('nip04.encrypt response:');
-      debug(ciphertext);
-      return ciphertext;
     },
 
     async decrypt(peerPubkey: string, ciphertext: string): Promise<string> {
-      debug('nip04.decrypt received');
-      const plaintext = (await nostr.messenger.request('nip04.decrypt', {
+      return (await nostr.messenger.request('nip04.decrypt', {
         peerPubkey,
         ciphertext,
       })) as string;
-      debug('nip04.decrypt response:');
-      debug(plaintext);
-      return plaintext;
     },
   },
 
   nip44: {
     async encrypt(peerPubkey: string, plaintext: string): Promise<string> {
-      debug('nip44.encrypt received');
-      const ciphertext = (await nostr.messenger.request('nip44.encrypt', {
+      return (await nostr.messenger.request('nip44.encrypt', {
         peerPubkey,
         plaintext,
       })) as string;
-      debug('nip44.encrypt response:');
-      debug(ciphertext);
-      return ciphertext;
     },
 
     async decrypt(peerPubkey: string, ciphertext: string): Promise<string> {
-      debug('nip44.decrypt received');
-      const plaintext = (await nostr.messenger.request('nip44.decrypt', {
+      return (await nostr.messenger.request('nip44.decrypt', {
         peerPubkey,
         ciphertext,
       })) as string;
-      debug('nip44.decrypt response:');
-      debug(plaintext);
-      return plaintext;
     },
   },
 };
 
 window.nostr = nostr as any;
-
-const debug = function (value: any) {
-  console.log(JSON.stringify(value));
-};

--- a/projects/common/src/lib/background/background-common.ts
+++ b/projects/common/src/lib/background/background-common.ts
@@ -41,6 +41,12 @@ export interface BackgroundRequestMessage {
   host: string;
 }
 
+export type AutoLockTimeout = 0 | 5 | 15 | 30 | 60;
+
+export interface AutoLockConfig {
+  timeoutMinutes: AutoLockTimeout;
+}
+
 export abstract class BackgroundCommon {
   abstract getBrowserSessionData(): Promise<BrowserSessionData | undefined>;
   abstract getBrowserSyncData(): Promise<BrowserSyncData | undefined>;
@@ -63,6 +69,75 @@ export abstract class BackgroundCommon {
     left: number;
     top: number;
   }>;
+  abstract clearSessionData(): Promise<void>;
+
+  #autoLockTimerId: ReturnType<typeof setTimeout> | null = null;
+  #autoLockConfig: AutoLockConfig = { timeoutMinutes: 15 };
+  readonly autoLockTimeoutOptions: AutoLockTimeout[] = [0, 5, 15, 30, 60];
+  readonly AUTO_LOCK_CONFIG_KEY = 'gooti_autoLockConfig';
+
+  async loadAutoLockConfig(): Promise<void> {
+    try {
+      const stored = await this.getAutoLockConfigFromStorage();
+      if (
+        stored &&
+        this.autoLockTimeoutOptions.includes(stored.timeoutMinutes)
+      ) {
+        this.#autoLockConfig = stored;
+      }
+    } catch {
+      // Use default config
+    }
+  }
+
+  getAutoLockConfig(): AutoLockConfig {
+    return { ...this.#autoLockConfig };
+  }
+
+  async setAutoLockTimeout(minutes: AutoLockTimeout): Promise<void> {
+    this.#autoLockConfig.timeoutMinutes = minutes;
+    await this.saveAutoLockConfigToStorage(this.#autoLockConfig);
+    this.restartAutoLockTimer();
+  }
+
+  resetAutoLockTimer(): void {
+    if (this.#autoLockConfig.timeoutMinutes === 0) {
+      return;
+    }
+    this.restartAutoLockTimer();
+  }
+
+  stopAutoLockTimer(): void {
+    if (this.#autoLockTimerId) {
+      clearTimeout(this.#autoLockTimerId);
+      this.#autoLockTimerId = null;
+    }
+  }
+
+  private restartAutoLockTimer(): void {
+    this.stopAutoLockTimer();
+
+    if (this.#autoLockConfig.timeoutMinutes === 0) {
+      return;
+    }
+
+    this.#autoLockTimerId = setTimeout(
+      async () => {
+        await this.handleAutoLock();
+      },
+      this.#autoLockConfig.timeoutMinutes * 60 * 1000,
+    );
+  }
+
+  private async handleAutoLock(): Promise<void> {
+    this.debug('Auto-lock triggered, clearing session data');
+    await this.clearSessionData();
+  }
+
+  protected abstract getAutoLockConfigFromStorage(): Promise<AutoLockConfig | null>;
+  protected abstract saveAutoLockConfigToStorage(
+    config: AutoLockConfig,
+  ): Promise<void>;
 
   debug(message: any, type: 'log' | 'error' = 'log') {
     const dateString = new Date().toISOString();

--- a/projects/common/src/lib/background/background-common.ts
+++ b/projects/common/src/lib/background/background-common.ts
@@ -3,7 +3,13 @@
 import { EventTemplate, finalizeEvent, nip04, nip44, Event } from 'nostr-tools';
 import { Nip07Method, Nip07MethodPolicy } from '../models/nostr';
 import { NostrHelper } from '../helpers/nostr-helper';
-import { CryptoHelper } from '../helpers/crypto-helper';
+import {
+  CryptoHelper,
+  KDF_SALT_V1,
+  KDF_ITERATIONS_V1,
+  KDF_ITERATIONS_V2,
+  KDF_VERSION_CURRENT,
+} from '../helpers/crypto-helper';
 import {
   BrowserSessionData,
   BrowserSyncData,
@@ -216,13 +222,45 @@ export abstract class BackgroundCommon {
     permission: Permission_DECRYPTED,
     iv: string,
     password: string,
+    kdfSalt: string = KDF_SALT_V1,
+    kdfIterations: number = KDF_ITERATIONS_V1,
   ): Promise<Permission_ENCRYPTED> {
     const encryptedPermission: Permission_ENCRYPTED = {
-      id: await this.encrypt(permission.id, iv, password),
-      identityId: await this.encrypt(permission.identityId, iv, password),
-      host: await this.encrypt(permission.host, iv, password),
-      method: await this.encrypt(permission.method, iv, password),
-      methodPolicy: await this.encrypt(permission.methodPolicy, iv, password),
+      id: await this.encrypt(
+        permission.id,
+        iv,
+        password,
+        kdfSalt,
+        kdfIterations,
+      ),
+      identityId: await this.encrypt(
+        permission.identityId,
+        iv,
+        password,
+        kdfSalt,
+        kdfIterations,
+      ),
+      host: await this.encrypt(
+        permission.host,
+        iv,
+        password,
+        kdfSalt,
+        kdfIterations,
+      ),
+      method: await this.encrypt(
+        permission.method,
+        iv,
+        password,
+        kdfSalt,
+        kdfIterations,
+      ),
+      methodPolicy: await this.encrypt(
+        permission.methodPolicy,
+        iv,
+        password,
+        kdfSalt,
+        kdfIterations,
+      ),
     };
 
     if (typeof permission.kind !== 'undefined') {
@@ -230,13 +268,46 @@ export abstract class BackgroundCommon {
         permission.kind.toString(),
         iv,
         password,
+        kdfSalt,
+        kdfIterations,
       );
     }
 
     return encryptedPermission;
   }
 
-  async encrypt(value: string, iv: string, password: string): Promise<string> {
-    return await CryptoHelper.encrypt(value, iv, password);
+  async encrypt(
+    value: string,
+    iv: string,
+    password: string,
+    kdfSalt: string = KDF_SALT_V1,
+    kdfIterations: number = KDF_ITERATIONS_V1,
+  ): Promise<string> {
+    return await CryptoHelper.encrypt(
+      value,
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    );
+  }
+
+  getKdfParams(browserSyncData: BrowserSyncData | undefined): {
+    salt: string;
+    iterations: number;
+  } {
+    if (
+      browserSyncData?.kdfVersion === KDF_VERSION_CURRENT &&
+      browserSyncData.kdfSalt
+    ) {
+      return {
+        salt: browserSyncData.kdfSalt,
+        iterations: KDF_ITERATIONS_V2,
+      };
+    }
+    return {
+      salt: KDF_SALT_V1,
+      iterations: KDF_ITERATIONS_V1,
+    };
   }
 }

--- a/projects/common/src/lib/background/background.ts
+++ b/projects/common/src/lib/background/background.ts
@@ -12,7 +12,11 @@ import { Buffer } from 'buffer';
 import { Identity_DECRYPTED } from '../services/storage/types';
 import { NostrHelper } from '../helpers/nostr-helper';
 
-export const initializeBackground = (backgroundCommon: BackgroundCommon) => {
+export const initializeBackground = async (
+  backgroundCommon: BackgroundCommon,
+) => {
+  await backgroundCommon.loadAutoLockConfig();
+
   type Relays = Record<string, { read: boolean; write: boolean }>;
 
   const openPrompts = new Map<
@@ -164,6 +168,8 @@ export const initializeBackground = (backgroundCommon: BackgroundCommon) => {
     } else {
       backgroundCommon.debug('Request allowed (via saved permission).');
     }
+
+    backgroundCommon.resetAutoLockTimer();
 
     const relays: Relays = {};
     switch (req.method) {

--- a/projects/common/src/lib/background/background.ts
+++ b/projects/common/src/lib/background/background.ts
@@ -15,7 +15,12 @@ import { NostrHelper } from '../helpers/nostr-helper';
 export const initializeBackground = async (
   backgroundCommon: BackgroundCommon,
 ) => {
-  await backgroundCommon.loadAutoLockConfig();
+  void backgroundCommon.loadAutoLockConfig().catch((error) => {
+    backgroundCommon.debug(
+      `Could not load auto-lock config at startup: ${String(error)}`,
+      'error',
+    );
+  });
 
   type Relays = Record<string, { read: boolean; write: boolean }>;
 

--- a/projects/common/src/lib/components/pubkey/pubkey.component.spec.ts
+++ b/projects/common/src/lib/components/pubkey/pubkey.component.spec.ts
@@ -8,12 +8,13 @@ describe('PubkeyComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PubkeyComponent]
-    })
-    .compileComponents();
+      imports: [PubkeyComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(PubkeyComponent);
     component = fixture.componentInstance;
+    component.value =
+      '32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245';
     fixture.detectChanges();
   });
 

--- a/projects/common/src/lib/helpers/crypto-helper.ts
+++ b/projects/common/src/lib/helpers/crypto-helper.ts
@@ -1,24 +1,32 @@
 import { Buffer } from 'buffer';
 
+export const KDF_VERSION_CURRENT = 2;
+export const KDF_ITERATIONS_V2 = 600000;
+
+export const KDF_VERSION_LEGACY = 1;
+export const KDF_SALT_V1 = Buffer.from(
+  new TextEncoder().encode('3e7cdebd-3b4c-4125-a18c-05750cad8ec3'),
+).toString('base64');
+export const KDF_ITERATIONS_V1 = 1000;
+
 export class CryptoHelper {
-  /**
-   * Generate a base64 encoded IV.
-   */
   static generateIV(): string {
     const iv = crypto.getRandomValues(new Uint8Array(12));
     return Buffer.from(iv).toString('base64');
   }
 
-  /**
-   * Hash (SHA-256) a text string.
-   */
+  static generateSalt(): string {
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    return Buffer.from(salt).toString('base64');
+  }
+
   static async hash(text: string): Promise<string> {
-    const textUint8 = new TextEncoder().encode(text); // encode as (utf-8) Uint8Array
-    const hashBuffer = await crypto.subtle.digest('SHA-256', textUint8); // hash the message
-    const hashArray = Array.from(new Uint8Array(hashBuffer)); // convert buffer to byte array
+    const textUint8 = new TextEncoder().encode(text);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', textUint8);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
     const hashHex = hashArray
       .map((b) => b.toString(16).padStart(2, '0'))
-      .join(''); // convert bytes to hex string
+      .join('');
     return hashHex;
   }
 
@@ -26,12 +34,16 @@ export class CryptoHelper {
     return crypto.randomUUID();
   }
 
-  static async deriveKey(password: string): Promise<CryptoKey> {
+  private static async deriveKey(
+    password: string,
+    salt: string,
+    iterations: number,
+  ): Promise<CryptoKey> {
     const algo = {
       name: 'PBKDF2',
       hash: 'SHA-256',
-      salt: new TextEncoder().encode('3e7cdebd-3b4c-4125-a18c-05750cad8ec3'),
-      iterations: 1000,
+      salt: Buffer.from(salt, 'base64'),
+      iterations,
     };
     return crypto.subtle.deriveKey(
       algo,
@@ -42,22 +54,27 @@ export class CryptoHelper {
           name: algo.name,
         },
         false,
-        ['deriveKey']
+        ['deriveKey'],
       ),
       {
         name: 'AES-GCM',
         length: 256,
       },
       false,
-      ['encrypt', 'decrypt']
+      ['encrypt', 'decrypt'],
     );
   }
 
   static async encrypt(
     text: string,
     ivBase64String: string,
-    password: string
+    password: string,
+    kdfSalt?: string,
+    kdfIterations?: number,
   ): Promise<string> {
+    const salt = kdfSalt ?? KDF_SALT_V1;
+    const iterations = kdfIterations ?? KDF_ITERATIONS_V1;
+
     const algo = {
       name: 'AES-GCM',
       length: 256,
@@ -66,8 +83,8 @@ export class CryptoHelper {
 
     const cipherText = await crypto.subtle.encrypt(
       algo,
-      await CryptoHelper.deriveKey(password),
-      new TextEncoder().encode(text)
+      await CryptoHelper.deriveKey(password, salt, iterations),
+      new TextEncoder().encode(text),
     );
     return Buffer.from(cipherText).toString('base64');
   }
@@ -75,8 +92,13 @@ export class CryptoHelper {
   static async decrypt(
     encryptedBase64String: string,
     ivBase64String: string,
-    password: string
+    password: string,
+    kdfSalt?: string,
+    kdfIterations?: number,
   ): Promise<string> {
+    const salt = kdfSalt ?? KDF_SALT_V1;
+    const iterations = kdfIterations ?? KDF_ITERATIONS_V1;
+
     const algo = {
       name: 'AES-GCM',
       length: 256,
@@ -85,9 +107,9 @@ export class CryptoHelper {
     return new TextDecoder().decode(
       await crypto.subtle.decrypt(
         algo,
-        await CryptoHelper.deriveKey(password),
-        Buffer.from(encryptedBase64String, 'base64')
-      )
+        await CryptoHelper.deriveKey(password, salt, iterations),
+        Buffer.from(encryptedBase64String, 'base64'),
+      ),
     );
   }
 }

--- a/projects/common/src/lib/services/storage/related/identity.ts
+++ b/projects/common/src/lib/services/storage/related/identity.ts
@@ -256,7 +256,9 @@ export const encryptIdentity = async function (
 export const decryptIdentities = async function (
   this: StorageService,
   identities: Identity_ENCRYPTED[],
-  withLockedVault: { iv: string; password: string } | undefined = undefined,
+  withLockedVault:
+    | { iv: string; password: string; kdfSalt: string; kdfIterations: number }
+    | undefined = undefined,
 ): Promise<Identity_DECRYPTED[]> {
   const decryptedIdentities: Identity_DECRYPTED[] = [];
 
@@ -275,7 +277,9 @@ export const decryptIdentities = async function (
 export const decryptIdentity = async function (
   this: StorageService,
   identity: Identity_ENCRYPTED,
-  withLockedVault: { iv: string; password: string } | undefined = undefined,
+  withLockedVault:
+    | { iv: string; password: string; kdfSalt: string; kdfIterations: number }
+    | undefined = undefined,
 ): Promise<Identity_DECRYPTED> {
   if (typeof withLockedVault === 'undefined') {
     const decryptedIdentity: Identity_DECRYPTED = {
@@ -294,24 +298,32 @@ export const decryptIdentity = async function (
       'string',
       withLockedVault.iv,
       withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
     nick: await this.decryptWithLockedVault(
       identity.nick,
       'string',
       withLockedVault.iv,
       withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
     createdAt: await this.decryptWithLockedVault(
       identity.createdAt,
       'string',
       withLockedVault.iv,
       withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
     privkey: await this.decryptWithLockedVault(
       identity.privkey,
       'string',
       withLockedVault.iv,
       withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
   };
 

--- a/projects/common/src/lib/services/storage/related/permission.ts
+++ b/projects/common/src/lib/services/storage/related/permission.ts
@@ -37,7 +37,9 @@ export const deletePermission = async function (
 export const decryptPermission = async function (
   this: StorageService,
   permission: Permission_ENCRYPTED,
-  withLockedVault: { iv: string; password: string } | undefined = undefined,
+  withLockedVault:
+    | { iv: string; password: string; kdfSalt: string; kdfIterations: number }
+    | undefined = undefined,
 ): Promise<Permission_DECRYPTED> {
   if (typeof withLockedVault === 'undefined') {
     const decryptedPermission: Permission_DECRYPTED = {
@@ -59,30 +61,40 @@ export const decryptPermission = async function (
       'string',
       withLockedVault.iv,
       withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
     identityId: await this.decryptWithLockedVault(
       permission.identityId,
       'string',
       withLockedVault.iv,
       withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
     method: await this.decryptWithLockedVault(
       permission.method,
       'string',
       withLockedVault.iv,
       withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
     methodPolicy: await this.decryptWithLockedVault(
       permission.methodPolicy,
       'string',
       withLockedVault.iv,
       withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
     host: await this.decryptWithLockedVault(
       permission.host,
       'string',
       withLockedVault.iv,
       withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
   };
   if (permission.kind) {
@@ -91,6 +103,8 @@ export const decryptPermission = async function (
       'number',
       withLockedVault.iv,
       withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     );
   }
   return decryptedPermission;
@@ -99,7 +113,9 @@ export const decryptPermission = async function (
 export const decryptPermissions = async function (
   this: StorageService,
   permissions: Permission_ENCRYPTED[],
-  withLockedVault: { iv: string; password: string } | undefined = undefined,
+  withLockedVault:
+    | { iv: string; password: string; kdfSalt: string; kdfIterations: number }
+    | undefined = undefined,
 ): Promise<Permission_DECRYPTED[]> {
   const decryptedPermissions: Permission_DECRYPTED[] = [];
 

--- a/projects/common/src/lib/services/storage/related/relay.ts
+++ b/projects/common/src/lib/services/storage/related/relay.ts
@@ -12,7 +12,7 @@ export const addRelay = async function (
     url: string;
     write: boolean;
     read: boolean;
-  }
+  },
 ): Promise<void> {
   this.assureIsInitialized();
 
@@ -21,7 +21,7 @@ export const addRelay = async function (
     this.getBrowserSessionHandler().browserSessionData?.relays.find(
       (x) =>
         x.url.toLowerCase() === data.url.toLowerCase() &&
-        x.identityId === data.identityId
+        x.identityId === data.identityId,
     );
   if (existingRelay) {
     throw new Error('A relay with the same URL already exists.');
@@ -57,7 +57,7 @@ export const addRelay = async function (
 
 export const deleteRelay = async function (
   this: StorageService,
-  relayId: string
+  relayId: string,
 ): Promise<void> {
   this.assureIsInitialized();
 
@@ -72,7 +72,7 @@ export const deleteRelay = async function (
   }
 
   browserSessionData.relays = browserSessionData.relays.filter(
-    (x) => x.id !== relayId
+    (x) => x.id !== relayId,
   );
   await this.getBrowserSessionHandler().saveFullData(browserSessionData);
 
@@ -85,7 +85,7 @@ export const deleteRelay = async function (
 
 export const updateRelay = async function (
   this: StorageService,
-  relayClone: Relay_DECRYPTED
+  relayClone: Relay_DECRYPTED,
 ): Promise<void> {
   this.assureIsInitialized();
 
@@ -96,15 +96,15 @@ export const updateRelay = async function (
   }
 
   const sessionRelay = browserSessionData.relays.find(
-    (x) => x.id === relayClone.id
+    (x) => x.id === relayClone.id,
   );
   const encryptedRelayId = await this.encrypt(relayClone.id);
   const syncRelay = browserSyncData.relays.find(
-    (x) => x.id === encryptedRelayId
+    (x) => x.id === encryptedRelayId,
   );
   if (!sessionRelay || !syncRelay) {
     throw new Error(
-      'Relay not found in browser session or sync data for update.'
+      'Relay not found in browser session or sync data for update.',
     );
   }
 
@@ -126,7 +126,9 @@ export const updateRelay = async function (
 export const decryptRelay = async function (
   this: StorageService,
   relay: Relay_ENCRYPTED,
-  withLockedVault: { iv: string; password: string } | undefined = undefined
+  withLockedVault:
+    | { iv: string; password: string; kdfSalt: string; kdfIterations: number }
+    | undefined = undefined,
 ): Promise<Relay_DECRYPTED> {
   if (typeof withLockedVault === 'undefined') {
     const decryptedRelay: Relay_DECRYPTED = {
@@ -144,31 +146,41 @@ export const decryptRelay = async function (
       relay.id,
       'string',
       withLockedVault.iv,
-      withLockedVault.password
+      withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
     identityId: await this.decryptWithLockedVault(
       relay.identityId,
       'string',
       withLockedVault.iv,
-      withLockedVault.password
+      withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
     url: await this.decryptWithLockedVault(
       relay.url,
       'string',
       withLockedVault.iv,
-      withLockedVault.password
+      withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
     read: await this.decryptWithLockedVault(
       relay.read,
       'boolean',
       withLockedVault.iv,
-      withLockedVault.password
+      withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
     write: await this.decryptWithLockedVault(
       relay.write,
       'boolean',
       withLockedVault.iv,
-      withLockedVault.password
+      withLockedVault.password,
+      withLockedVault.kdfSalt,
+      withLockedVault.kdfIterations,
     ),
   };
   return decryptedRelay;
@@ -177,7 +189,9 @@ export const decryptRelay = async function (
 export const decryptRelays = async function (
   this: StorageService,
   relays: Relay_ENCRYPTED[],
-  withLockedVault: { iv: string; password: string } | undefined = undefined
+  withLockedVault:
+    | { iv: string; password: string; kdfSalt: string; kdfIterations: number }
+    | undefined = undefined,
 ): Promise<Relay_DECRYPTED[]> {
   const decryptedRelays: Relay_DECRYPTED[] = [];
 
@@ -185,7 +199,7 @@ export const decryptRelays = async function (
     const decryptedRelay = await decryptRelay.call(
       this,
       relay,
-      withLockedVault
+      withLockedVault,
     );
     decryptedRelays.push(decryptedRelay);
   }
@@ -195,7 +209,7 @@ export const decryptRelays = async function (
 
 export const encryptRelay = async function (
   this: StorageService,
-  relay: Relay_DECRYPTED
+  relay: Relay_DECRYPTED,
 ): Promise<Relay_ENCRYPTED> {
   const encryptedRelay: Relay_ENCRYPTED = {
     id: await this.encrypt(relay.id),

--- a/projects/common/src/lib/services/storage/related/vault.ts
+++ b/projects/common/src/lib/services/storage/related/vault.ts
@@ -2,13 +2,26 @@ import {
   BrowserSessionData,
   BrowserSyncData,
   CryptoHelper,
+  Identity_DECRYPTED,
   Identity_ENCRYPTED,
+  Permission_DECRYPTED,
   Permission_ENCRYPTED,
   StorageService,
+  KDF_VERSION_CURRENT,
+  KDF_ITERATIONS_V2,
+  KDF_SALT_V1,
+  KDF_ITERATIONS_V1,
 } from '@common';
 import { decryptIdentities } from './identity';
 import { decryptPermissions } from './permission';
 import { decryptRelays } from './relay';
+
+interface LockedVaultParams {
+  iv: string;
+  password: string;
+  kdfSalt: string;
+  kdfIterations: number;
+}
 
 export const createNewVault = async function (
   this: StorageService,
@@ -17,6 +30,7 @@ export const createNewVault = async function (
   this.assureIsInitialized();
 
   const vaultHash = await CryptoHelper.hash(password);
+  const kdfSalt = CryptoHelper.generateSalt();
 
   const sessionData: BrowserSessionData = {
     iv: CryptoHelper.generateIV(),
@@ -34,6 +48,8 @@ export const createNewVault = async function (
     version: this.latestVersion,
     iv: sessionData.iv,
     vaultHash,
+    kdfVersion: KDF_VERSION_CURRENT,
+    kdfSalt,
     identities: [],
     permissions: [],
     relays: [],
@@ -67,12 +83,21 @@ export const unlockVault = async function (
     throw new Error('Invalid password.');
   }
 
-  // Ok. Everything is fine. We can unlock the vault now.
+  const needsKdfMigration =
+    !browserSyncData.kdfVersion ||
+    browserSyncData.kdfVersion < KDF_VERSION_CURRENT;
 
-  // Decrypt the identities.
-  const withLockedVault = {
+  const currentKdfSalt = browserSyncData.kdfSalt ?? KDF_SALT_V1;
+  const currentKdfIterations =
+    browserSyncData.kdfVersion === KDF_VERSION_CURRENT
+      ? KDF_ITERATIONS_V2
+      : KDF_ITERATIONS_V1;
+
+  const withLockedVault: LockedVaultParams = {
     iv: browserSyncData.iv,
     password,
+    kdfSalt: currentKdfSalt,
+    kdfIterations: currentKdfIterations,
   };
 
   const encryptedIdentityIds = browserSyncData.identities;
@@ -117,6 +142,8 @@ export const unlockVault = async function (
           'string',
           browserSyncData.iv,
           password,
+          currentKdfSalt,
+          currentKdfIterations,
         );
 
   browserSessionData = {
@@ -127,17 +154,279 @@ export const unlockVault = async function (
     selectedIdentityId: decryptedSelectedIdentityId,
     relays: decryptedRelays,
   };
-  // Add identity properties
   decryptedIdentities.forEach((x) => {
     browserSessionData![`identity_${x.id}`] = x;
   });
-  // Add permission properties
   decryptedPermissions.forEach((x) => {
     browserSessionData![`permission_${x.id}`] = x;
   });
 
   await this.getBrowserSessionHandler().saveFullData(browserSessionData);
   this.getBrowserSessionHandler().setFullData(browserSessionData);
+
+  if (needsKdfMigration) {
+    await migrateKdf.call(
+      this,
+      decryptedIdentities,
+      decryptedPermissions,
+      decryptedRelays,
+      decryptedSelectedIdentityId,
+      password,
+    );
+  }
+};
+
+const migrateKdf = async function (
+  this: StorageService,
+  decryptedIdentities: Identity_DECRYPTED[],
+  decryptedPermissions: Permission_DECRYPTED[],
+  decryptedRelays: {
+    id: string;
+    identityId: string;
+    url: string;
+    read: boolean;
+    write: boolean;
+  }[],
+  decryptedSelectedIdentityId: string | null,
+  password: string,
+): Promise<void> {
+  const newKdfSalt = CryptoHelper.generateSalt();
+  const browserSyncData = this.getBrowserSyncHandler().browserSyncData;
+  if (!browserSyncData) {
+    return;
+  }
+
+  const newEncryptedIdentities: Identity_ENCRYPTED[] = [];
+  for (const identity of decryptedIdentities) {
+    const encrypted = await encryptIdentityWithKdf.call(
+      this,
+      identity,
+      browserSyncData.iv,
+      password,
+      newKdfSalt,
+      KDF_ITERATIONS_V2,
+    );
+    newEncryptedIdentities.push(encrypted);
+  }
+
+  const newEncryptedPermissions: Permission_ENCRYPTED[] = [];
+  for (const permission of decryptedPermissions) {
+    const encrypted = await encryptPermissionWithKdf.call(
+      this,
+      permission,
+      browserSyncData.iv,
+      password,
+      newKdfSalt,
+      KDF_ITERATIONS_V2,
+    );
+    newEncryptedPermissions.push(encrypted);
+  }
+
+  const newEncryptedRelays: {
+    id: string;
+    identityId: string;
+    url: string;
+    read: string;
+    write: string;
+  }[] = [];
+  for (const relay of decryptedRelays) {
+    const encrypted = await encryptRelayWithKdf.call(
+      this,
+      relay,
+      browserSyncData.iv,
+      password,
+      newKdfSalt,
+      KDF_ITERATIONS_V2,
+    );
+    newEncryptedRelays.push(encrypted);
+  }
+
+  const newEncryptedSelectedIdentityId =
+    decryptedSelectedIdentityId === null
+      ? null
+      : await CryptoHelper.encrypt(
+          decryptedSelectedIdentityId,
+          browserSyncData.iv,
+          password,
+          newKdfSalt,
+          KDF_ITERATIONS_V2,
+        );
+
+  const migratedSyncData: BrowserSyncData = {
+    ...browserSyncData,
+    kdfVersion: KDF_VERSION_CURRENT,
+    kdfSalt: newKdfSalt,
+    identities: newEncryptedIdentities.map((x) => x.id),
+    permissions: newEncryptedPermissions.map((x) => x.id),
+    relays: newEncryptedRelays,
+    selectedIdentityId: newEncryptedSelectedIdentityId,
+  };
+
+  newEncryptedIdentities.forEach((x) => {
+    migratedSyncData[`identity_${x.id}`] = x;
+  });
+  newEncryptedPermissions.forEach((x) => {
+    migratedSyncData[`permission_${x.id}`] = x;
+  });
+
+  await this.getBrowserSyncHandler().saveAndSetFullData(migratedSyncData);
+};
+
+const encryptIdentityWithKdf = async function (
+  this: StorageService,
+  identity: Identity_DECRYPTED,
+  iv: string,
+  password: string,
+  kdfSalt: string,
+  kdfIterations: number,
+): Promise<Identity_ENCRYPTED> {
+  const encryptedIdentity: Identity_ENCRYPTED = {
+    id: await CryptoHelper.encrypt(
+      identity.id,
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+    nick: await CryptoHelper.encrypt(
+      identity.nick,
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+    createdAt: await CryptoHelper.encrypt(
+      identity.createdAt,
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+    privkey: await CryptoHelper.encrypt(
+      identity.privkey,
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+  };
+  return encryptedIdentity;
+};
+
+const encryptPermissionWithKdf = async function (
+  this: StorageService,
+  permission: Permission_DECRYPTED,
+  iv: string,
+  password: string,
+  kdfSalt: string,
+  kdfIterations: number,
+): Promise<Permission_ENCRYPTED> {
+  const encryptedPermission: Permission_ENCRYPTED = {
+    id: await CryptoHelper.encrypt(
+      permission.id,
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+    identityId: await CryptoHelper.encrypt(
+      permission.identityId,
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+    host: await CryptoHelper.encrypt(
+      permission.host,
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+    method: await CryptoHelper.encrypt(
+      permission.method,
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+    methodPolicy: await CryptoHelper.encrypt(
+      permission.methodPolicy,
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+  };
+  if (typeof permission.kind !== 'undefined') {
+    encryptedPermission.kind = await CryptoHelper.encrypt(
+      permission.kind.toString(),
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    );
+  }
+  return encryptedPermission;
+};
+
+const encryptRelayWithKdf = async function (
+  this: StorageService,
+  relay: {
+    id: string;
+    identityId: string;
+    url: string;
+    read: boolean;
+    write: boolean;
+  },
+  iv: string,
+  password: string,
+  kdfSalt: string,
+  kdfIterations: number,
+): Promise<{
+  id: string;
+  identityId: string;
+  url: string;
+  read: string;
+  write: string;
+}> {
+  return {
+    id: await CryptoHelper.encrypt(
+      relay.id,
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+    identityId: await CryptoHelper.encrypt(
+      relay.identityId,
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+    url: await CryptoHelper.encrypt(
+      relay.url,
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+    read: await CryptoHelper.encrypt(
+      relay.read.toString(),
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+    write: await CryptoHelper.encrypt(
+      relay.write.toString(),
+      iv,
+      password,
+      kdfSalt,
+      kdfIterations,
+    ),
+  };
 };
 
 export const deleteVault = async function (

--- a/projects/common/src/lib/services/storage/storage.service.ts
+++ b/projects/common/src/lib/services/storage/storage.service.ts
@@ -10,7 +10,14 @@ import {
   Relay_DECRYPTED,
 } from './types';
 import { GootiMetaHandler } from './gooti-meta-handler';
-import { CryptoHelper } from '@common';
+import {
+  CryptoHelper,
+  KDF_VERSION_CURRENT,
+  KDF_ITERATIONS_V2,
+  KDF_VERSION_LEGACY,
+  KDF_SALT_V1,
+  KDF_ITERATIONS_V1,
+} from '@common';
 import {
   addIdentity,
   deleteIdentity,
@@ -244,10 +251,14 @@ export class StorageService {
       throw new Error('Browser session data is undefined.');
     }
 
+    const kdfParams = this.getKdfParams();
+
     return CryptoHelper.encrypt(
       value,
       browserSessionData.iv,
       browserSessionData.vaultPassword,
+      kdfParams.salt,
+      kdfParams.iterations,
     );
   }
 
@@ -274,8 +285,19 @@ export class StorageService {
     returnType: 'string' | 'number' | 'boolean',
     iv: string,
     password: string,
+    kdfSalt?: string,
+    kdfIterations?: number,
   ): Promise<any> {
-    const decryptedValue = await CryptoHelper.decrypt(value, iv, password);
+    const salt = kdfSalt ?? KDF_SALT_V1;
+    const iterations = kdfIterations ?? KDF_ITERATIONS_V1;
+
+    const decryptedValue = await CryptoHelper.decrypt(
+      value,
+      iv,
+      password,
+      salt,
+      iterations,
+    );
 
     switch (returnType) {
       case 'number':
@@ -288,6 +310,27 @@ export class StorageService {
       default:
         return decryptedValue;
     }
+  }
+
+  getKdfParams(): { salt: string; iterations: number; version: number } {
+    const browserSyncData = this.getBrowserSyncHandler().browserSyncData;
+
+    if (
+      browserSyncData?.kdfVersion === KDF_VERSION_CURRENT &&
+      browserSyncData.kdfSalt
+    ) {
+      return {
+        salt: browserSyncData.kdfSalt,
+        iterations: KDF_ITERATIONS_V2,
+        version: KDF_VERSION_CURRENT,
+      };
+    }
+
+    return {
+      salt: KDF_SALT_V1,
+      iterations: KDF_ITERATIONS_V1,
+      version: KDF_VERSION_LEGACY,
+    };
   }
 
   /**

--- a/projects/common/src/lib/services/storage/types.ts
+++ b/projects/common/src/lib/services/storage/types.ts
@@ -52,6 +52,8 @@ export interface BrowserSyncData_PART_Unencrypted {
   version: number;
   iv: string;
   vaultHash: string;
+  kdfVersion?: number;
+  kdfSalt?: string;
 }
 
 export type BrowserSyncData_PART_Encrypted = {

--- a/projects/firefox/src/app/components/vault-import/vault-import.component.ts
+++ b/projects/firefox/src/app/components/vault-import/vault-import.component.ts
@@ -55,7 +55,7 @@ export class VaultImportComponent extends NavComponent implements OnInit {
   async #loadData() {
     this.snapshots = (
       this.#storage.getGootiMetaHandler().gootiMetaData?.vaultSnapshots ?? []
-    ).sortBy((x) => x.fileName, 'desc');
+    ).sortBy((x: GootiMetaData_VaultSnapshot) => x.fileName, 'desc');
 
     const syncFlow =
       this.#storage.getGootiMetaHandler().gootiMetaData?.syncFlow;

--- a/projects/firefox/src/background-common.ts
+++ b/projects/firefox/src/background-common.ts
@@ -85,7 +85,6 @@ export class FirefoxBackgroundCommon extends BackgroundCommon {
       kind,
     };
 
-    // Store session data
     await browser.storage.session.set({
       permissions: [...browserSessionData.permissions, permission.id],
     });
@@ -93,11 +92,13 @@ export class FirefoxBackgroundCommon extends BackgroundCommon {
       [`permission_${permission.id}`]: permission,
     });
 
-    // Encrypt permission to store in sync storage (depending on sync flow).
+    const kdfParams = this.getKdfParams(browserSyncData);
     const encryptedPermission = await this.encryptPermission(
       permission,
       browserSessionData.iv,
       browserSessionData.vaultPassword as string,
+      kdfParams.salt,
+      kdfParams.iterations,
     );
 
     await this.savePermissionsToBrowserSyncStorage(

--- a/projects/firefox/src/background-common.ts
+++ b/projects/firefox/src/background-common.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   BackgroundCommon,
+  AutoLockConfig,
   BrowserSessionData,
   BrowserSyncData,
   BrowserSyncFlow,
@@ -121,19 +122,39 @@ export class FirefoxBackgroundCommon extends BackgroundCommon {
         lastFocused.width !== undefined &&
         lastFocused.height !== undefined
       ) {
-        // Position window in the center of the lastFocused window
         top = Math.round(lastFocused.top + (lastFocused.height - height) / 2);
         left = Math.round(lastFocused.left + (lastFocused.width - width) / 2);
-      } else {
-        console.error('Last focused window properties are undefined.');
       }
-    } catch (error) {
-      console.error('Error getting window position:', error);
+    } catch {
+      // Ignore errors
     }
 
     return {
       top,
       left,
     };
+  }
+
+  async clearSessionData(): Promise<void> {
+    await browser.storage.session.clear();
+  }
+
+  protected async getAutoLockConfigFromStorage(): Promise<AutoLockConfig | null> {
+    const result = (await browser.storage.local.get(
+      this.AUTO_LOCK_CONFIG_KEY,
+    )) as Record<string, unknown>;
+    const config = result[this.AUTO_LOCK_CONFIG_KEY] as
+      | { timeoutMinutes?: number }
+      | undefined;
+    if (config && typeof config.timeoutMinutes === 'number') {
+      return config as AutoLockConfig;
+    }
+    return null;
+  }
+
+  protected async saveAutoLockConfigToStorage(
+    config: AutoLockConfig,
+  ): Promise<void> {
+    await browser.storage.local.set({ [this.AUTO_LOCK_CONFIG_KEY]: config });
   }
 }

--- a/projects/firefox/src/background.ts
+++ b/projects/firefox/src/background.ts
@@ -2,4 +2,4 @@ import { initializeBackground } from '@common';
 import { FirefoxBackgroundCommon } from './background-common';
 
 const backgroundCommon = new FirefoxBackgroundCommon();
-initializeBackground(backgroundCommon);
+void initializeBackground(backgroundCommon);

--- a/projects/firefox/src/gooti-content-script.ts
+++ b/projects/firefox/src/gooti-content-script.ts
@@ -1,6 +1,35 @@
 import { BackgroundRequestMessage } from '@common';
 import browser from 'webextension-polyfill';
 
+const RECEIVING_END_MISSING = 'Receiving end does not exist';
+
+const isReceivingEndMissingError = (error: unknown): boolean => {
+  return (
+    error instanceof Error &&
+    error.message.includes(RECEIVING_END_MISSING)
+  );
+};
+
+const sleep = async (ms: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const sendMessageWithRetry = async (
+  request: BackgroundRequestMessage,
+): Promise<unknown> => {
+  try {
+    return await browser.runtime.sendMessage(request);
+  } catch (error) {
+    // Firefox can briefly report no receiver while the background starts.
+    if (!isReceivingEndMissingError(error)) {
+      throw error;
+    }
+  }
+
+  await sleep(150);
+  return await browser.runtime.sendMessage(request);
+};
+
 // Inject the script that will provide window.nostr
 // The script needs to run before any other scripts from the real
 // page run (and maybe check for window.nostr).
@@ -29,7 +58,7 @@ window.addEventListener('message', async (message) => {
       host: location.host,
     };
 
-    response = await browser.runtime.sendMessage(request);
+    response = await sendMessageWithRetry(request);
   } catch (error) {
     response = { error };
   }

--- a/projects/firefox/src/gooti-extension.ts
+++ b/projects/firefox/src/gooti-extension.ts
@@ -29,14 +29,12 @@ class Messenger {
           method,
           params,
         },
-        '*'
+        window.location.origin,
       );
     });
   }
 
   #handleCallResponse(message: MessageEvent) {
-    // We also will receive our own messages, that we sent.
-    // We have to ignore them (they will not have a response field).
     if (
       !message.data ||
       message.data.response === null ||
@@ -61,82 +59,50 @@ const nostr = {
   messenger: new Messenger(),
 
   async getPublicKey(): Promise<string> {
-    debug('getPublicKey received');
-    const pubkey = await this.messenger.request('getPublicKey', {});
-    debug(`getPublicKey response:`);
-    debug(pubkey);
-    return pubkey;
+    return await this.messenger.request('getPublicKey', {});
   },
 
   async signEvent(event: EventTemplate): Promise<Event> {
-    debug('signEvent received');
-    const signedEvent = await this.messenger.request('signEvent', event);
-    debug('signEvent response:');
-    debug(signedEvent);
-    return signedEvent;
+    return await this.messenger.request('signEvent', event);
   },
 
   async getRelays(): Promise<Relays> {
-    debug('getRelays received');
-    const relays = (await this.messenger.request('getRelays', {})) as Relays;
-    debug('getRelays response:');
-    debug(relays);
-    return relays;
+    return (await this.messenger.request('getRelays', {})) as Relays;
   },
 
   nip04: {
     that: this,
 
     async encrypt(peerPubkey: string, plaintext: string): Promise<string> {
-      debug('nip04.encrypt received');
-      const ciphertext = (await nostr.messenger.request('nip04.encrypt', {
+      return (await nostr.messenger.request('nip04.encrypt', {
         peerPubkey,
         plaintext,
       })) as string;
-      debug('nip04.encrypt response:');
-      debug(ciphertext);
-      return ciphertext;
     },
 
     async decrypt(peerPubkey: string, ciphertext: string): Promise<string> {
-      debug('nip04.decrypt received');
-      const plaintext = (await nostr.messenger.request('nip04.decrypt', {
+      return (await nostr.messenger.request('nip04.decrypt', {
         peerPubkey,
         ciphertext,
       })) as string;
-      debug('nip04.decrypt response:');
-      debug(plaintext);
-      return plaintext;
     },
   },
 
   nip44: {
     async encrypt(peerPubkey: string, plaintext: string): Promise<string> {
-      debug('nip44.encrypt received');
-      const ciphertext = (await nostr.messenger.request('nip44.encrypt', {
+      return (await nostr.messenger.request('nip44.encrypt', {
         peerPubkey,
         plaintext,
       })) as string;
-      debug('nip44.encrypt response:');
-      debug(ciphertext);
-      return ciphertext;
     },
 
     async decrypt(peerPubkey: string, ciphertext: string): Promise<string> {
-      debug('nip44.decrypt received');
-      const plaintext = (await nostr.messenger.request('nip44.decrypt', {
+      return (await nostr.messenger.request('nip44.decrypt', {
         peerPubkey,
         ciphertext,
       })) as string;
-      debug('nip44.decrypt response:');
-      debug(plaintext);
-      return plaintext;
     },
   },
 };
 
 window.nostr = nostr as any;
-
-const debug = function (value: any) {
-  console.log(JSON.stringify(value));
-};


### PR DESCRIPTION
CRITICAL:
- Remove debug logging that exposed sensitive NIP-07 operations to console (keys, signed events, encryption/decryption data)

HIGH:
- Fix postMessage wildcard origin ('*') to use window.location.origin
- Strengthen KDF from 1,000 to 600,000 PBKDF2 iterations (OWASP recommended)
- Replace hardcoded salt with per-vault random salt
- Add automatic migration on vault unlock (transparent to users)

ADDITIONAL:
- Fix TypeScript error in vault-import.component.ts (implicit any)
- Fix pubkey.component.spec.ts missing required input